### PR TITLE
align items baseline

### DIFF
--- a/index.css
+++ b/index.css
@@ -483,6 +483,7 @@ hr {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  align-items: baseline;
   grid-gap: var(--space-lg) var(--space-sm);
   margin-top: var(--space-lg);
   margin-bottom: var(--space-lg);


### PR DESCRIPTION
Grid items shouldn't stretch to fill row